### PR TITLE
Add vita2d_draw_texture_scale_rotate

### DIFF
--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -84,6 +84,7 @@ void vita2d_draw_texture_rotate_hotspot(const vita2d_texture *texture, float x, 
 void vita2d_draw_texture_scale(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale);
 void vita2d_draw_texture_part(const vita2d_texture *texture, float x, float y, float tex_x, float tex_y, float tex_w, float tex_h);
 void vita2d_draw_texture_part_scale(const vita2d_texture *texture, float x, float y, float tex_x, float tex_y, float tex_w, float tex_h, float x_scale, float y_scale);
+void vita2d_draw_texture_scale_rotate(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale, float rad);
 
 void vita2d_draw_texture_tint(const vita2d_texture *texture, float x, float y, unsigned int color);
 void vita2d_draw_texture_tint_rotate(const vita2d_texture *texture, float x, float y, float rad, unsigned int color);

--- a/libvita2d/source/vita2d_texture.c
+++ b/libvita2d/source/vita2d_texture.c
@@ -544,3 +544,73 @@ void vita2d_draw_texture_tint_part_scale(const vita2d_texture *texture, float x,
 	set_texture_tint_color_uniform(color);
 	draw_texture_part_scale_generic(texture, x, y, tex_x, tex_y, tex_w, tex_h, x_scale, y_scale);
 }
+
+static inline void draw_texture_scale_rotate_hotspot_generic(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale, float rad, float center_x, float center_y)
+{
+	vita2d_texture_vertex *vertices = (vita2d_texture_vertex *)vita2d_pool_memalign(
+		4 * sizeof(vita2d_texture_vertex), // 4 vertices
+		sizeof(vita2d_texture_vertex));
+
+	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
+		4 * sizeof(uint16_t), // 4 indices
+		sizeof(uint16_t));
+
+	const float w = x_scale * vita2d_texture_get_width(texture);
+	const float h = y_scale * vita2d_texture_get_height(texture);
+	const float center_x_scaled = x_scale * center_x;
+	const float center_y_scaled = y_scale * center_y;
+
+
+	vertices[0].x = -center_x_scaled;
+	vertices[0].y = -center_y_scaled;
+	vertices[0].z = +0.5f;
+	vertices[0].u = 0.0f;
+	vertices[0].v = 0.0f;
+
+	vertices[1].x = -center_x_scaled + w;
+	vertices[1].y = -center_y_scaled;
+	vertices[1].z = +0.5f;
+	vertices[1].u = 1.0f;
+	vertices[1].v = 0.0f;
+
+	vertices[2].x = -center_x_scaled;
+	vertices[2].y = -center_y_scaled + h;
+	vertices[2].z = +0.5f;
+	vertices[2].u = 0.0f;
+	vertices[2].v = 1.0f;
+
+	vertices[3].x = -center_x_scaled + w;
+	vertices[3].y = -center_y_scaled + h;
+	vertices[3].z = +0.5f;
+	vertices[3].u = 1.0f;
+	vertices[3].v = 1.0f;
+
+	float c = cosf(rad);
+	float s = sinf(rad);
+	int i;
+	for (i = 0; i < 4; ++i) { // Rotate and translate
+		float _x = vertices[i].x;
+		float _y = vertices[i].y;
+		vertices[i].x = _x*c - _y*s + x + center_x_scaled;
+		vertices[i].y = _x*s + _y*c + y + center_y_scaled;
+	}
+
+	indices[0] = 0;
+	indices[1] = 1;
+	indices[2] = 2;
+	indices[3] = 3;
+
+	// Set the texture to the TEXUNIT0
+	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
+
+	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+}
+
+void vita2d_draw_texture_scale_rotate(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale, float rad){
+		set_texture_program();
+		set_texture_wvp_uniform();
+		draw_texture_scale_rotate_hotspot_generic(texture, x, y, x_scale, y_scale,
+			rad, vita2d_texture_get_width(texture)/2.0f,
+			vita2d_texture_get_height(texture)/2.0f);
+}


### PR DESCRIPTION
In the future it will be better to have vertices as parameter and to have rotate, scale, translate functions.

This is for vita2d_gfx_driver on retroarch
