### PR TITLE
Make upscaling text look slightly less shit

### DIFF
--- a/libvita2d/source/texture_atlas.c
+++ b/libvita2d/source/texture_atlas.c
@@ -27,7 +27,7 @@ texture_atlas *texture_atlas_create(int width, int height, SceGxmTextureFormat f
 
 	vita2d_texture_set_filters(atlas->texture,
 				   SCE_GXM_TEXTURE_FILTER_POINT,
-				   SCE_GXM_TEXTURE_FILTER_POINT);
+				   SCE_GXM_TEXTURE_FILTER_LINEAR);
 
 	return atlas;
 }


### PR DESCRIPTION
Upscaling a tiny font by 1.25 shouldn't look like pixelly garbage.
