### PR TITLE
Support multiple system fonts

### DIFF
--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -4,6 +4,7 @@
 #include <psp2/gxm.h>
 #include <psp2/types.h>
 #include <psp2/kernel/sysmem.h>
+#include <psp2/pgf.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,6 +37,11 @@ typedef struct vita2d_texture {
 	SceUID data_UID;
 	SceUID palette_UID;
 } vita2d_texture;
+
+typedef struct vita2d_system_pgf_config {
+	SceFontLanguageCode code;
+	int (*in_font_group)(unsigned int c);
+} vita2d_system_pgf_config;
 
 typedef struct vita2d_font vita2d_font;
 typedef struct vita2d_pgf vita2d_pgf;
@@ -122,6 +128,7 @@ int vita2d_font_text_width(vita2d_font *font, unsigned int size, const char *tex
 int vita2d_font_text_height(vita2d_font *font, unsigned int size, const char *text);
 
 /* PGF functions are weak imports at the moment, they have to be resolved manually */
+vita2d_pgf *vita2d_load_system_pgf(int numFonts, const vita2d_system_pgf_config *configs);
 vita2d_pgf *vita2d_load_default_pgf();
 vita2d_pgf *vita2d_load_custom_pgf(const char *path);
 void vita2d_free_pgf(vita2d_pgf *font);


### PR DESCRIPTION
basic idea from http://pastebin.com/Wk03Wniz

actually, we already have `vita2d_load_custom_pgf`, but sometimes just want to use system fonts.
new function `vita2d_load_system_pgf` receive two arguments; font count and font finding configs

config must set [language code](https://github.com/vitasdk/vita-headers/blob/fbc72d2/include/psp2/pgf.h#L79-L86%29) and function pointer about group checking of character set.

code example

```
int is_korean_char(unsigned int c) {
    unsigned short ch = c;
    // hangul compatibility jamo block
    if (0x3130 <= ch && ch <= 0x318f) {
        return 1;
    }
    // hangul syllables block
    if (0xac00 <= ch && ch <= 0xd7af) {
        return 1;
    }
    // korean won sign
    if (ch == 0xffe6) {
        return 1;
    }
    return 0;
}

int is_latin_char(unsigned int c) {
    unsigned short ch = c;
    // basic latin block + latin-1 supplement block
    if (ch <= 0x00ff) {
        return 1;
    }
    // cyrillic block
    if (0x0400 <= ch && ch <= 0x04ff) {
        return 1;
    }
    return 0;
}

int main() {
    // ...
    vita2d_system_pgf_config configs[] = {
        {SCE_FONT_LANGUAGE_KOREAN,  is_korean_char},
        {SCE_FONT_LANGUAGE_LATIN,   is_latin_char},
        {SCE_FONT_LANGUAGE_DEFAULT, NULL},
    };

    vita2d_pgf* font = vita2d_load_system_pgf(3, configs);
    // ...
}
```
