### PR TITLE
Calculate tex_size to include stride alignment.

### DIFF
--- a/libvita2d/source/vita2d_texture.c
+++ b/libvita2d/source/vita2d_texture.c
@@ -61,7 +61,8 @@ vita2d_texture *vita2d_create_empty_texture_format(unsigned int w, unsigned int 
 	if (!texture)
 		return NULL;
 
-	const int tex_size =  w * h * tex_format_to_bytespp(format);
+	const int stride = ((w * tex_format_to_bytespp(format)) + SCE_GXM_TEXTURE_ALIGNMENT - 1) & ~(SCE_GXM_TEXTURE_ALIGNMENT - 1);
+	const int tex_size = stride * h;
 
 	/* Allocate a GPU buffer for the texture */
 	void *texture_data = gpu_alloc(


### PR DESCRIPTION
I'm not entirely sure what the rules are for texture stride, but I have observed that initialising a 32-bit texture of width 5 results in a stride of 32 bytes and not 20.

Maybe stride needs to be aligned, or maybe it has a minimum, I don't know.
