### PR TITLE
Allocating indices buffer at startup only.

### DIFF
--- a/libvita2d/source/vita2d.c
+++ b/libvita2d/source/vita2d.c
@@ -126,6 +126,10 @@ static SceUID poolUid;
 static unsigned int pool_index = 0;
 static unsigned int pool_size = 0;
 
+// Indices buffer
+static SceUID indicesUid;
+void *indices_buf_addr = NULL;
+
 /* Static functions */
 
 static void *patcher_host_alloc(void *user_data, unsigned int size)
@@ -618,6 +622,21 @@ int vita2d_init_advanced(unsigned int temp_pool_size)
 		sizeof(void *),
 		SCE_GXM_MEMORY_ATTRIB_READ,
 		&poolUid);
+		
+	// Allocate memory for indices buffer
+	indices_buf_addr = gpu_alloc(
+		SCE_KERNEL_MEMBLOCK_TYPE_USER_RW,
+		4 * sizeof(uint16_t),
+		sizeof(void *),
+		SCE_GXM_MEMORY_ATTRIB_READ,
+		&indicesUid);
+		
+	// Initializing indices buffer
+	uint16_t *indices = (uint16_t*)indices_buf_addr;
+	indices[0] = 0;
+	indices[1] = 1;
+	indices[2] = 2;
+	indices[3] = 3;
 
 	matrix_init_orthographic(_vita2d_ortho_matrix, 0.0f, DISPLAY_WIDTH, DISPLAY_HEIGHT, 0.0f, 0.0f, 1.0f);
 
@@ -705,6 +724,7 @@ int vita2d_fini()
 	free(contextParams.hostMem);
 
 	gpu_free(poolUid);
+	gpu_free(indicesUid);
 
 	// terminate libgxm
 	sceGxmTerminate();

--- a/libvita2d/source/vita2d_draw.c
+++ b/libvita2d/source/vita2d_draw.c
@@ -2,6 +2,8 @@
 #include "vita2d.h"
 #include "shared.h"
 
+extern void *indices_buf_addr;
+
 void vita2d_draw_pixel(float x, float y, unsigned int color)
 {
 	vita2d_color_vertex *vertex = (vita2d_color_vertex *)vita2d_pool_memalign(
@@ -38,10 +40,6 @@ void vita2d_draw_line(float x0, float y0, float x1, float y1, unsigned int color
 		2 * sizeof(vita2d_color_vertex), // 2 vertices
 		sizeof(vita2d_color_vertex));
 
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		2 * sizeof(uint16_t), // 2 indices
-		sizeof(uint16_t));
-
 	vertices[0].x = x0;
 	vertices[0].y = y0;
 	vertices[0].z = +0.5f;
@@ -52,9 +50,6 @@ void vita2d_draw_line(float x0, float y0, float x1, float y1, unsigned int color
 	vertices[1].z = +0.5f;
 	vertices[1].color = color;
 
-	indices[0] = 0;
-	indices[1] = 1;
-
 	sceGxmSetVertexProgram(_vita2d_context, _vita2d_colorVertexProgram);
 	sceGxmSetFragmentProgram(_vita2d_context, _vita2d_colorFragmentProgram);
 
@@ -64,7 +59,7 @@ void vita2d_draw_line(float x0, float y0, float x1, float y1, unsigned int color
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
 	sceGxmSetFrontPolygonMode(_vita2d_context, SCE_GXM_POLYGON_MODE_LINE);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_LINES, SCE_GXM_INDEX_FORMAT_U16, indices, 2);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_LINES, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 2);
 	sceGxmSetFrontPolygonMode(_vita2d_context, SCE_GXM_POLYGON_MODE_TRIANGLE_FILL);
 }
 
@@ -73,10 +68,6 @@ void vita2d_draw_rectangle(float x, float y, float w, float h, unsigned int colo
 	vita2d_color_vertex *vertices = (vita2d_color_vertex *)vita2d_pool_memalign(
 		4 * sizeof(vita2d_color_vertex), // 4 vertices
 		sizeof(vita2d_color_vertex));
-
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
 
 	vertices[0].x = x;
 	vertices[0].y = y;
@@ -98,11 +89,6 @@ void vita2d_draw_rectangle(float x, float y, float w, float h, unsigned int colo
 	vertices[3].z = +0.5f;
 	vertices[3].color = color;
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	sceGxmSetVertexProgram(_vita2d_context, _vita2d_colorVertexProgram);
 	sceGxmSetFragmentProgram(_vita2d_context, _vita2d_colorFragmentProgram);
 
@@ -111,7 +97,7 @@ void vita2d_draw_rectangle(float x, float y, float w, float h, unsigned int colo
 	sceGxmSetUniformDataF(vertexDefaultBuffer, _vita2d_colorWvpParam, 0, 16, _vita2d_ortho_matrix);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_fill_circle(float x, float y, float radius, unsigned int color)
@@ -125,7 +111,6 @@ void vita2d_draw_fill_circle(float x, float y, float radius, unsigned int color)
 	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
 		(num_segments + 2) * sizeof(uint16_t),
 		sizeof(uint16_t));
-
 
 	vertices[0].x = x;
 	vertices[0].y = y;

--- a/libvita2d/source/vita2d_texture.c
+++ b/libvita2d/source/vita2d_texture.c
@@ -9,6 +9,8 @@
 #define GXM_TEX_MAX_SIZE 4096
 static SceKernelMemBlockType MemBlockType = SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW;
 
+extern void *indices_buf_addr;
+
 static int tex_format_to_bytespp(SceGxmTextureFormat format)
 {
 	switch (format & 0x9f000000U) {
@@ -303,10 +305,6 @@ static inline void draw_texture_generic(const vita2d_texture *texture, float x, 
 		4 * sizeof(vita2d_texture_vertex), // 4 vertices
 		sizeof(vita2d_texture_vertex));
 
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
-
 	const float w = vita2d_texture_get_width(texture);
 	const float h = vita2d_texture_get_height(texture);
 
@@ -334,16 +332,11 @@ static inline void draw_texture_generic(const vita2d_texture *texture, float x, 
 	vertices[3].u = 1.0f;
 	vertices[3].v = 1.0f;
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	// Set the texture to the TEXUNIT0
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_texture(const vita2d_texture *texture, float x, float y)
@@ -382,10 +375,6 @@ static inline void draw_texture_rotate_hotspot_generic(const vita2d_texture *tex
 		4 * sizeof(vita2d_texture_vertex), // 4 vertices
 		sizeof(vita2d_texture_vertex));
 
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
-
 	const float w = vita2d_texture_get_width(texture);
 	const float h = vita2d_texture_get_height(texture);
 
@@ -423,16 +412,11 @@ static inline void draw_texture_rotate_hotspot_generic(const vita2d_texture *tex
 		vertices[i].y = _x*s + _y*c + y;
 	}
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	// Set the texture to the TEXUNIT0
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_texture_rotate_hotspot(const vita2d_texture *texture, float x, float y, float rad, float center_x, float center_y)
@@ -455,10 +439,6 @@ static inline void draw_texture_scale_generic(const vita2d_texture *texture, flo
 	vita2d_texture_vertex *vertices = (vita2d_texture_vertex *)vita2d_pool_memalign(
 		4 * sizeof(vita2d_texture_vertex), // 4 vertices
 		sizeof(vita2d_texture_vertex));
-
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
 
 	const float w = x_scale * vita2d_texture_get_width(texture);
 	const float h = y_scale * vita2d_texture_get_height(texture);
@@ -487,16 +467,11 @@ static inline void draw_texture_scale_generic(const vita2d_texture *texture, flo
 	vertices[3].u = 1.0f;
 	vertices[3].v = 1.0f;
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	// Set the texture to the TEXUNIT0
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_texture_scale(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale)
@@ -520,10 +495,6 @@ static inline void draw_texture_part_generic(const vita2d_texture *texture, floa
 	vita2d_texture_vertex *vertices = (vita2d_texture_vertex *)vita2d_pool_memalign(
 		4 * sizeof(vita2d_texture_vertex), // 4 vertices
 		sizeof(vita2d_texture_vertex));
-
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
 
 	const float w = vita2d_texture_get_width(texture);
 	const float h = vita2d_texture_get_height(texture);
@@ -557,16 +528,11 @@ static inline void draw_texture_part_generic(const vita2d_texture *texture, floa
 	vertices[3].u = u1;
 	vertices[3].v = v1;
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	// Set the texture to the TEXUNIT0
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_texture_part(const vita2d_texture *texture, float x, float y, float tex_x, float tex_y, float tex_w, float tex_h)
@@ -589,10 +555,6 @@ static inline void draw_texture_part_scale_generic(const vita2d_texture *texture
 	vita2d_texture_vertex *vertices = (vita2d_texture_vertex *)vita2d_pool_memalign(
 		4 * sizeof(vita2d_texture_vertex), // 4 vertices
 		sizeof(vita2d_texture_vertex));
-
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
 
 	const float w = vita2d_texture_get_width(texture);
 	const float h = vita2d_texture_get_height(texture);
@@ -629,16 +591,11 @@ static inline void draw_texture_part_scale_generic(const vita2d_texture *texture
 	vertices[3].u = u1;
 	vertices[3].v = v1;
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	// Set the texture to the TEXUNIT0
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_texture_part_scale(const vita2d_texture *texture, float x, float y, float tex_x, float tex_y, float tex_w, float tex_h, float x_scale, float y_scale)
@@ -661,10 +618,6 @@ static inline void draw_texture_scale_rotate_hotspot_generic(const vita2d_textur
 	vita2d_texture_vertex *vertices = (vita2d_texture_vertex *)vita2d_pool_memalign(
 		4 * sizeof(vita2d_texture_vertex), // 4 vertices
 		sizeof(vita2d_texture_vertex));
-
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
 
 	const float w = x_scale * vita2d_texture_get_width(texture);
 	const float h = y_scale * vita2d_texture_get_height(texture);
@@ -705,16 +658,11 @@ static inline void draw_texture_scale_rotate_hotspot_generic(const vita2d_textur
 		vertices[i].y = _x*s + _y*c + y;
 	}
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	// Set the texture to the TEXUNIT0
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_texture_scale_rotate_hotspot(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale, float rad, float center_x, float center_y)
@@ -754,10 +702,6 @@ static inline void draw_texture_part_scale_rotate_generic(const vita2d_texture *
 	vita2d_texture_vertex *vertices = (vita2d_texture_vertex *)vita2d_pool_memalign(
 		4 * sizeof(vita2d_texture_vertex), // 4 vertices
 		sizeof(vita2d_texture_vertex));
-
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(
-		4 * sizeof(uint16_t), // 4 indices
-		sizeof(uint16_t));
 
 	const float w_full = vita2d_texture_get_width(texture);
 	const float h_full = vita2d_texture_get_height(texture);
@@ -804,16 +748,11 @@ static inline void draw_texture_part_scale_rotate_generic(const vita2d_texture *
 		vertices[i].y = _x*s + _y*c + y;
 	}
 
-	indices[0] = 0;
-	indices[1] = 1;
-	indices[2] = 2;
-	indices[3] = 3;
-
 	// Set the texture to the TEXUNIT0
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
 }
 
 void vita2d_draw_texture_part_scale_rotate(const vita2d_texture *texture, float x, float y,


### PR DESCRIPTION
This will give a double win-win:

- Mempool won't be flooded with indices whenever a draw call will be performed.
- All drawing calls will be faster.