### PR TITLE
Allow drawing of arbitrary colored and textured polygons

### DIFF
--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -134,6 +134,7 @@ void vita2d_draw_texture_tint_part_scale(const vita2d_texture *texture, float x,
 void vita2d_draw_texture_tint_scale_rotate_hotspot(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale, float rad, float center_x, float center_y, unsigned int color);
 void vita2d_draw_texture_tint_scale_rotate(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale, float rad, unsigned int color);
 void vita2d_draw_texture_part_tint_scale_rotate(const vita2d_texture *texture, float x, float y, float tex_x, float tex_y, float tex_w, float tex_h, float x_scale, float y_scale, float rad, unsigned int color);
+void vita2d_draw_array_textured(const vita2d_texture *texture, SceGxmPrimitiveType mode, const vita2d_texture_vertex *vertices, size_t count, unsigned int color);
 
 vita2d_texture *vita2d_load_PNG_file(const char *filename);
 vita2d_texture *vita2d_load_PNG_buffer(const void *buffer);

--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -95,6 +95,7 @@ void vita2d_draw_pixel(float x, float y, unsigned int color);
 void vita2d_draw_line(float x0, float y0, float x1, float y1, unsigned int color);
 void vita2d_draw_rectangle(float x, float y, float w, float h, unsigned int color);
 void vita2d_draw_fill_circle(float x, float y, float radius, unsigned int color);
+void vita2d_draw_array(SceGxmPrimitiveType mode, const vita2d_color_vertex *vertices, size_t count);
 
 void vita2d_texture_set_alloc_memblock_type(SceKernelMemBlockType type);
 SceKernelMemBlockType vita2d_texture_get_alloc_memblock_type();

--- a/libvita2d/source/vita2d_draw.c
+++ b/libvita2d/source/vita2d_draw.c
@@ -151,3 +151,23 @@ void vita2d_draw_fill_circle(float x, float y, float radius, unsigned int color)
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
 	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_FAN, SCE_GXM_INDEX_FORMAT_U16, indices, num_segments + 2);
 }
+
+void vita2d_draw_array(SceGxmPrimitiveType mode, const vita2d_color_vertex *vertices, size_t count)
+{
+	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(count * sizeof(uint16_t), sizeof(uint16_t));
+	for (int i = 0; i<count; i++) {
+		indices[i] = i;
+	}
+
+	sceGxmSetVertexProgram(_vita2d_context, _vita2d_colorVertexProgram);
+	sceGxmSetFragmentProgram(_vita2d_context, _vita2d_colorFragmentProgram);
+
+	void *vertexDefaultBuffer;
+	sceGxmReserveVertexDefaultUniformBuffer(_vita2d_context, &vertexDefaultBuffer);
+	sceGxmSetUniformDataF(vertexDefaultBuffer, _vita2d_colorWvpParam, 0, 16, _vita2d_ortho_matrix);
+
+	sceGxmSetBackPolygonMode(_vita2d_context, SCE_GXM_POLYGON_MODE_TRIANGLE_FILL);
+
+	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
+	sceGxmDraw(_vita2d_context, mode, SCE_GXM_INDEX_FORMAT_U16, indices, count);
+}

--- a/libvita2d/source/vita2d_texture.c
+++ b/libvita2d/source/vita2d_texture.c
@@ -773,3 +773,23 @@ void vita2d_draw_texture_part_tint_scale_rotate(const vita2d_texture *texture, f
 	draw_texture_part_scale_rotate_generic(texture, x, y,
 		tex_x, tex_y, tex_w, tex_h, x_scale, y_scale, rad);
 }
+
+void vita2d_draw_array_textured(const vita2d_texture *texture, SceGxmPrimitiveType mode, const vita2d_texture_vertex *vertices, size_t count, unsigned int color)
+{
+	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(count * sizeof(uint16_t), sizeof(uint16_t));
+	for (int i = 0; i<count; i++) {
+		indices[i] = i;
+	}
+
+	set_texture_tint_program();
+	set_texture_wvp_uniform();
+	set_texture_tint_color_uniform(color);
+
+	sceGxmSetBackPolygonMode(_vita2d_context, SCE_GXM_POLYGON_MODE_TRIANGLE_FILL);
+
+	// Set the texture to the TEXUNIT0
+	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
+
+	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
+	sceGxmDraw(_vita2d_context, mode, SCE_GXM_INDEX_FORMAT_U16, indices, count);
+}

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -11,6 +11,10 @@ CC      = $(PREFIX)-gcc
 CFLAGS  = -Wl,-q -Wall -fno-lto
 ASFLAGS = $(CFLAGS)
 
+# Link against the locally-built version of libvita2d if possible
+LIBS += -L../libvita2d
+CFLAGS += -I../libvita2d/include
+
 all: $(TARGET).vpk
 
 %.vpk: eboot.bin

--- a/sample/main.c
+++ b/sample/main.c
@@ -73,6 +73,30 @@ int main()
 
 		vita2d_draw_array(SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, vertices, n_vertices);
 
+		size_t nslices = 50;
+		size_t n_tvertices = 6 * nslices;
+		vita2d_texture_vertex *tvertices = (vita2d_texture_vertex *)vita2d_pool_memalign(
+			n_tvertices * sizeof(vita2d_texture_vertex),
+			sizeof(vita2d_texture_vertex));
+
+		for (int slice=0; slice<nslices; slice++) {
+			float a = (float)slice/(float)nslices;
+			float b = (float)(slice+1)/(float)nslices;
+
+			vita2d_texture_vertex *v = &tvertices[slice*6];
+			(v++)->u = a; (v++)->u = a; (v++)->u = b;
+			(v++)->u = a; (v++)->u = b; (v++)->u = b;
+		}
+
+		for (int i=0; i<n_tvertices; ++i) {
+			tvertices[i].v = i % 2;
+			tvertices[i].x = 720.f + 200.f * tvertices[i].u;
+			tvertices[i].y = 100.f + 200.f * tvertices[i].v + 10.f * sinf(tvertices[i].u*(3.f+40.f*fabsf(sinf(rad*0.1f)))+rad);
+			tvertices[i].z = 0.5f;
+		}
+
+		vita2d_draw_array_textured(image, SCE_GXM_PRIMITIVE_TRIANGLES, tvertices, n_tvertices, RGBA8(0xFF, 0xFF, 0xFF, 0xFF));
+
 		vita2d_end_drawing();
 		vita2d_swap_buffers();
 

--- a/sample/main.c
+++ b/sample/main.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <math.h>
 
 #include <psp2/ctrl.h>
 #include <psp2/kernel/processmgr.h>
@@ -57,6 +58,20 @@ int main()
 		vita2d_pgf_draw_text(pgf, 700, 30, RGBA8(0,255,0,255), 1.0f, "PGF Font sample!");
 
 		vita2d_pvf_draw_text(pvf, 700, 80, RGBA8(0,255,0,255), 1.0f, "PVF Font sample!");
+
+		size_t n_vertices = 69;
+		vita2d_color_vertex *vertices = (vita2d_color_vertex *)vita2d_pool_memalign(
+			n_vertices * sizeof(vita2d_color_vertex),
+			sizeof(vita2d_color_vertex));
+
+		for (int i=0; i<n_vertices; ++i) {
+			vertices[i].x = 830.f + 100.f * fabsf(sinf(i*10.f+rad)) * sinf(i*0.1f+rad*0.4f);
+			vertices[i].y = 420.f + 100.f * fabsf(sinf(i*10.f+rad)) * cosf(i*0.1f+rad*0.4f);
+			vertices[i].z = 0.5f;
+			vertices[i].color = RGBA8(0xff-i*2, i*3, 0x8a-2*i, 0x80);
+		}
+
+		vita2d_draw_array(SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, vertices, n_vertices);
 
 		vita2d_end_drawing();
 		vita2d_swap_buffers();


### PR DESCRIPTION
This adds two new functions that give more control over rendering arbitrary polygons (and/or batching draw calls) while still leaving all the platform abstraction (setting up shader programs, etc...) to libvita2d.

    void vita2d_draw_array(SceGxmPrimitiveType mode, const vita2d_color_vertex *vertices, size_t count);
    void vita2d_draw_array_textured(const vita2d_texture *texture, SceGxmPrimitiveType mode, const vita2d_texture_vertex *vertices, size_t count, unsigned int color);

Example code (test case) is also included.