### PR TITLE
vita2d_set_blend_mode_add(): Additive blending mode

### DIFF
--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -85,6 +85,7 @@ void vita2d_disable_clipping();
 int vita2d_get_clipping_enabled();
 void vita2d_set_clip_rectangle(int x_min, int y_min, int x_max, int y_max);
 void vita2d_get_clip_rectangle(int *x_min, int *y_min, int *x_max, int *y_max);
+void vita2d_set_blend_mode_add(int enable);
 
 void *vita2d_pool_malloc(unsigned int size);
 void *vita2d_pool_memalign(unsigned int size, unsigned int alignment);

--- a/sample/main.c
+++ b/sample/main.c
@@ -97,6 +97,11 @@ int main()
 
 		vita2d_draw_array_textured(image, SCE_GXM_PRIMITIVE_TRIANGLES, tvertices, n_tvertices, RGBA8(0xFF, 0xFF, 0xFF, 0xFF));
 
+		vita2d_draw_rectangle(40, 40, 100, 100, RGBA8(128, 64, 192, 255));
+		vita2d_set_blend_mode_add(1);
+		vita2d_draw_rectangle(40, 60, 200, 60, RGBA8(0, 100, 0, 128));
+		vita2d_set_blend_mode_add(0);
+
 		vita2d_end_drawing();
 		vita2d_swap_buffers();
 


### PR DESCRIPTION
Not sure if this is the best way, or if the library user should be able to e.g. create a set of fragment programs from a `SceGxmBlendInfo` and then have a function for setting those programs active.