### PR TITLE
Use a single, static index buffer

### DIFF
--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -78,6 +78,7 @@ void vita2d_set_vblank_wait(int enable);
 void *vita2d_get_current_fb();
 SceGxmContext *vita2d_get_context();
 SceGxmShaderPatcher *vita2d_get_shader_patcher();
+const uint16_t *vita2d_get_linear_indices();
 
 void vita2d_set_region_clip(SceGxmRegionClipMode mode, unsigned int x_min, unsigned int y_min, unsigned int x_max, unsigned int y_max);
 void vita2d_enable_clipping();

--- a/libvita2d/source/vita2d_draw.c
+++ b/libvita2d/source/vita2d_draw.c
@@ -2,8 +2,6 @@
 #include "vita2d.h"
 #include "shared.h"
 
-extern void *indices_buf_addr;
-
 void vita2d_draw_pixel(float x, float y, unsigned int color)
 {
 	vita2d_color_vertex *vertex = (vita2d_color_vertex *)vita2d_pool_memalign(
@@ -59,7 +57,7 @@ void vita2d_draw_line(float x0, float y0, float x1, float y1, unsigned int color
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
 	sceGxmSetFrontPolygonMode(_vita2d_context, SCE_GXM_POLYGON_MODE_LINE);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_LINES, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 2);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_LINES, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 2);
 	sceGxmSetFrontPolygonMode(_vita2d_context, SCE_GXM_POLYGON_MODE_TRIANGLE_FILL);
 }
 
@@ -97,7 +95,7 @@ void vita2d_draw_rectangle(float x, float y, float w, float h, unsigned int colo
 	sceGxmSetUniformDataF(vertexDefaultBuffer, _vita2d_colorWvpParam, 0, 16, _vita2d_ortho_matrix);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_fill_circle(float x, float y, float radius, unsigned int color)
@@ -154,11 +152,6 @@ void vita2d_draw_fill_circle(float x, float y, float radius, unsigned int color)
 
 void vita2d_draw_array(SceGxmPrimitiveType mode, const vita2d_color_vertex *vertices, size_t count)
 {
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(count * sizeof(uint16_t), sizeof(uint16_t));
-	for (int i = 0; i<count; i++) {
-		indices[i] = i;
-	}
-
 	sceGxmSetVertexProgram(_vita2d_context, _vita2d_colorVertexProgram);
 	sceGxmSetFragmentProgram(_vita2d_context, _vita2d_colorFragmentProgram);
 
@@ -169,5 +162,5 @@ void vita2d_draw_array(SceGxmPrimitiveType mode, const vita2d_color_vertex *vert
 	sceGxmSetBackPolygonMode(_vita2d_context, SCE_GXM_POLYGON_MODE_TRIANGLE_FILL);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, mode, SCE_GXM_INDEX_FORMAT_U16, indices, count);
+	sceGxmDraw(_vita2d_context, mode, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), count);
 }

--- a/libvita2d/source/vita2d_texture.c
+++ b/libvita2d/source/vita2d_texture.c
@@ -9,8 +9,6 @@
 #define GXM_TEX_MAX_SIZE 4096
 static SceKernelMemBlockType MemBlockType = SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW;
 
-extern void *indices_buf_addr;
-
 static int tex_format_to_bytespp(SceGxmTextureFormat format)
 {
 	switch (format & 0x9f000000U) {
@@ -336,7 +334,7 @@ static inline void draw_texture_generic(const vita2d_texture *texture, float x, 
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_texture(const vita2d_texture *texture, float x, float y)
@@ -416,7 +414,7 @@ static inline void draw_texture_rotate_hotspot_generic(const vita2d_texture *tex
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_texture_rotate_hotspot(const vita2d_texture *texture, float x, float y, float rad, float center_x, float center_y)
@@ -471,7 +469,7 @@ static inline void draw_texture_scale_generic(const vita2d_texture *texture, flo
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_texture_scale(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale)
@@ -532,7 +530,7 @@ static inline void draw_texture_part_generic(const vita2d_texture *texture, floa
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_texture_part(const vita2d_texture *texture, float x, float y, float tex_x, float tex_y, float tex_w, float tex_h)
@@ -595,7 +593,7 @@ static inline void draw_texture_part_scale_generic(const vita2d_texture *texture
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_texture_part_scale(const vita2d_texture *texture, float x, float y, float tex_x, float tex_y, float tex_w, float tex_h, float x_scale, float y_scale)
@@ -662,7 +660,7 @@ static inline void draw_texture_scale_rotate_hotspot_generic(const vita2d_textur
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_texture_scale_rotate_hotspot(const vita2d_texture *texture, float x, float y, float x_scale, float y_scale, float rad, float center_x, float center_y)
@@ -752,7 +750,7 @@ static inline void draw_texture_part_scale_rotate_generic(const vita2d_texture *
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, indices_buf_addr, 4);
+	sceGxmDraw(_vita2d_context, SCE_GXM_PRIMITIVE_TRIANGLE_STRIP, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), 4);
 }
 
 void vita2d_draw_texture_part_scale_rotate(const vita2d_texture *texture, float x, float y,
@@ -776,11 +774,6 @@ void vita2d_draw_texture_part_tint_scale_rotate(const vita2d_texture *texture, f
 
 void vita2d_draw_array_textured(const vita2d_texture *texture, SceGxmPrimitiveType mode, const vita2d_texture_vertex *vertices, size_t count, unsigned int color)
 {
-	uint16_t *indices = (uint16_t *)vita2d_pool_memalign(count * sizeof(uint16_t), sizeof(uint16_t));
-	for (int i = 0; i<count; i++) {
-		indices[i] = i;
-	}
-
 	set_texture_tint_program();
 	set_texture_wvp_uniform();
 	set_texture_tint_color_uniform(color);
@@ -791,5 +784,5 @@ void vita2d_draw_array_textured(const vita2d_texture *texture, SceGxmPrimitiveTy
 	sceGxmSetFragmentTexture(_vita2d_context, 0, &texture->gxm_tex);
 
 	sceGxmSetVertexStream(_vita2d_context, 0, vertices);
-	sceGxmDraw(_vita2d_context, mode, SCE_GXM_INDEX_FORMAT_U16, indices, count);
+	sceGxmDraw(_vita2d_context, mode, SCE_GXM_INDEX_FORMAT_U16, vita2d_get_linear_indices(), count);
 }


### PR DESCRIPTION
This takes up 128 KiB of VRAM (64k possible indexes * 2 bytes per index), but makes it easier to basically do "non-indexed" drawing by specifying linearly increasing index numbers. It's done once at initialization time, right now all possible 16-bit index values are accounted for, but maybe that could be an optional initialization parameter (maximum index).