### PR TITLE
Delayed texture deletion (Fixes #28)

### DIFF
--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -105,7 +105,15 @@ vita2d_texture *vita2d_create_empty_texture(unsigned int w, unsigned int h);
 vita2d_texture *vita2d_create_empty_texture_format(unsigned int w, unsigned int h, SceGxmTextureFormat format);
 vita2d_texture *vita2d_create_empty_texture_rendertarget(unsigned int w, unsigned int h, SceGxmTextureFormat format);
 
+// Mark texture for deletion; will be deleted at next vita2d_swap_buffers() or
+// when vita2d_gc_textures() is called (to avoid GPU crashes when deleting
+// textures still required by the GPU to finish rendering the current frame)
 void vita2d_free_texture(vita2d_texture *texture);
+
+// This will be called automatically by vita2d_swap_buffers(), but you can call
+// it earlier in case you allocate/deallocate many textures in a single frame;
+// returns the number of texture objects freed
+int vita2d_gc_textures();
 
 unsigned int vita2d_texture_get_width(const vita2d_texture *texture);
 unsigned int vita2d_texture_get_height(const vita2d_texture *texture);

--- a/libvita2d/source/vita2d.c
+++ b/libvita2d/source/vita2d.c
@@ -738,6 +738,10 @@ int vita2d_fini()
 	// wait until rendering is done
 	sceGxmFinish(_vita2d_context);
 
+	// in case vita2d_free_texture() was called after the last vita2d_swap_buffers(),
+	// we need to GC textures here again, otherwise we would leak texture objects
+	vita2d_gc_textures();
+
 	// clean up allocations
 	sceGxmShaderPatcherReleaseFragmentProgram(shaderPatcher, clearFragmentProgram);
 	sceGxmShaderPatcherReleaseVertexProgram(shaderPatcher, clearVertexProgram);
@@ -844,6 +848,9 @@ void vita2d_swap_buffers()
 		frontBufferIndex = backBufferIndex;
 		backBufferIndex = (backBufferIndex + 1) % DISPLAY_BUFFER_COUNT;
 	}
+
+	// free any textures marked for deletion
+	vita2d_gc_textures();
 }
 
 void vita2d_start_drawing()


### PR DESCRIPTION
Since I ran into a crash a few times already by now, here's a patch that delays the "real" deletion of the texture until a swap operation (or until `vita2d_gc_textures()` is called manually).

This way, a library user can just allocate and free textures normally and not have to worry about freeing textures too early, vita2d will take care of delaying the deletion until the next swap. Note that right now *all* free texture operations are delayed, even in cases where a texture wasn't used in the current frame (and could potentially be freed immediately).

Apart from the linked list overhead, the only situation when this would be bad is if an application allocates and frees textures while drawing, and these free operations are delayed until the swap. But for this case, the application developer can use `vita2d_gc_textures()` to explicitly flush the free operations before `vita2d_swap_buffers()`.