### PR TITLE
Add Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,12 +14,12 @@ steps:
 
 - script: |
     cd libvita2d
-    export PREFIX=arm-vita-eabi
+    export PREFIX=distrib/arm-vita-eabi
     make install
   displayName: 'Install in isolated dir'
 
 - task: PublishPipelineArtifact@1
   inputs:
-    path: libvita2d/arm-vita-eabi
+    path: libvita2d/distrib
     artifact: 'vita2d package'
   displayName: 'Upload vita2d to artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,25 @@
+
+# https://aka.ms/yaml
+
+pool:
+  vmImage: 'ubuntu-16.04'
+
+container: gnuton/vitasdk-docker:latest
+
+steps:
+- script: |
+    cd libvita2d
+    make
+  displayName: 'Build'
+
+- script: |
+    cd libvita2d
+    export PREFIX=arm-vita-eabi
+    make install
+  displayName: 'Install in isolated dir'
+
+- task: PublishPipelineArtifact@1
+  inputs:
+    path: libvita2d/arm-vita-eabi
+    artifact: 'vita2d package'
+  displayName: 'Upload vita2d to artifacts'


### PR DESCRIPTION
- I'm only compiling the library, not the sample. This can be changed very easily however.
- Can be adapted to use CMake once https://github.com/xerpi/libvita2d/pull/77 is merged.
- You can see how it looks like here: https://dev.azure.com/devnoname120/devnoname120/_build/results?buildId=43
- Every build also has an associated built libvita2d, you can find it in the 'Artifacts' section.
- I'm using the latest vitasdk at all times, might want (or not) to pin a specific vitasdk version: https://hub.docker.com/r/gnuton/vitasdk-docker/tags