### PR TITLE
Fixed crashing with certain JPEG/PNG files

### DIFF
--- a/libvita2d/source/vita2d_image_jpeg.c
+++ b/libvita2d/source/vita2d_image_jpeg.c
@@ -70,7 +70,7 @@ vita2d_texture *vita2d_load_JPEG_file(const char *filename)
 	fread(&magic, 1, sizeof(unsigned int), fp);
 	fseek(fp, 0, SEEK_SET);
 
-	if (magic != 0xE0FFD8FF && magic != 0xE1FFD8FF) {
+	if (magic != 0xE0FFD8FF && magic != 0xE1FFD8FF && magic != 0xDBFFD8FF) {
 		fclose(fp);
 		return NULL;
 	}

--- a/libvita2d/source/vita2d_texture.c
+++ b/libvita2d/source/vita2d_texture.c
@@ -61,7 +61,7 @@ static vita2d_texture *_vita2d_create_empty_texture_format_advanced(unsigned int
 	if (!texture)
 		return NULL;
 
-	const int tex_size =  w * h * tex_format_to_bytespp(format);
+	const int tex_size =  ((w + 7) & ~ 7) * h * tex_format_to_bytespp(format);
 
 	/* Allocate a GPU buffer for the texture */
 	void *texture_data = gpu_alloc(


### PR DESCRIPTION
Changed `w` to `((w + 7) & ~ 7)` as mentioned [here](https://github.com/xerpi/libvita2d/issues/75#issuecomment-509446713) in vita2d_texture.c to add compensation for the stride of the texture. (This was the main cause of the crashing for seemingly valid JPEG/PNG files)

Also added the `0xDBFFD8FF` file header for another type of JPEG file supported by libjpeg-turbo so that the function wont return null when the headers are checked and the file can actually be loaded.