### PR TITLE
Added -lSceAppMgr_stub to libs in the sample

### DIFF
--- a/sample/Makefile
+++ b/sample/Makefile
@@ -4,7 +4,7 @@ OBJS     = main.o image.o
 
 LIBS = -lvita2d -lSceDisplay_stub -lSceGxm_stub \
 	-lSceSysmodule_stub -lSceCtrl_stub -lScePgf_stub -lScePvf_stub \
-	-lSceCommonDialog_stub -lfreetype -lpng -ljpeg -lz -lm -lc
+	-lSceCommonDialog_stub -lfreetype -lpng -ljpeg -lz -lm -lc -lSceAppMgr_stub
 
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc


### PR DESCRIPTION
Due to system mode being added, -lSceAppMgr_stub was required in libvita2d projects,
Now, the sample can compile.