### PR TITLE
Improve logic for scale jpg images

### DIFF
--- a/libvita2d/source/vita2d_image_jpeg.c
+++ b/libvita2d/source/vita2d_image_jpeg.c
@@ -6,23 +6,14 @@
 #include <jpeglib.h>
 #include "vita2d.h"
 
+// Following official documentation max width or height of the texture is 4096
+#define MAX_TEXTURE 4096
+
 static vita2d_texture *_vita2d_load_JPEG_generic(struct jpeg_decompress_struct *jinfo, struct jpeg_error_mgr *jerr)
 {
-	float downScaleWidth = (float)jinfo->image_width / 4096;
-	float downScaleHeight = (float)jinfo->image_height / 4096;
-	float downScale = (downScaleWidth >= downScaleHeight) ? downScaleWidth : downScaleHeight;
-
-	if (downScale <= 1.f) {
-		jinfo->scale_denom = 1;
-	} else if (downScale <= 2.f) {
-		jinfo->scale_denom = 2;
-	} else if (downScale <= 4.f) {
-		jinfo->scale_denom = 4;
-	} else if (downScale <= 8.f) {
-		jinfo->scale_denom = 8;
-	} else {
-		return NULL;
-	}
+	unsigned int longer = jinfo->image_width > jinfo->image_height ? jinfo->image_width : jinfo->image_height;
+	float downScale = (float)longer / (float)MAX_TEXTURE;
+	jinfo->scale_denom = ceil(downScale);
 
 	jpeg_start_decompress(jinfo);
 


### PR DESCRIPTION
# Description
This PR basically improves the logic for scaling down jpg images.
Now it checks instead by width or height, by matrix size, making better scaling down for any kind of image aspect ratio.

I have checked the documentation of `libjpeg-turbo` and they mention this:
```
unsigned int scale_num, scale_denom
        Scale the image by the fraction scale_num/scale_denom.  Default is
        1/1, or no scaling.  Currently, the only supported scaling ratios
        are M/8 with all M from 1 to 16, or any reduced fraction thereof (such
        as 1/2, 3/4, etc.)  (The library design allows for arbitrary
        scaling ratios but this is not likely to be implemented any time soon.)
        Smaller scaling ratios permit significantly faster decoding since
        fewer pixels need be processed and a simpler IDCT method can be used.
```

I have done some tests and the library admit any value of `scale_denom` greater than 1, maybe documentation is outdated

Thanks

