### PR TITLE
Fix building with recent VitaSDK Changes

### DIFF
--- a/libvita2d/include/utils.h
+++ b/libvita2d/include/utils.h
@@ -14,7 +14,7 @@
 int utf8_to_ucs2(const char *utf8, unsigned int *character);
 
 /* GPU utils */
-void *gpu_alloc(SceKernelMemBlockType type, unsigned int size, unsigned int alignment, unsigned int attribs, SceUID *uid);
+void *gpu_alloc(unsigned int type, unsigned int size, unsigned int alignment, unsigned int attribs, SceUID *uid);
 void gpu_free(SceUID uid);
 void *vertex_usse_alloc(unsigned int size, SceUID *uid, unsigned int *usse_offset);
 void vertex_usse_free(SceUID uid);

--- a/libvita2d/include/vita2d.h
+++ b/libvita2d/include/vita2d.h
@@ -99,8 +99,8 @@ void vita2d_draw_rectangle(float x, float y, float w, float h, unsigned int colo
 void vita2d_draw_fill_circle(float x, float y, float radius, unsigned int color);
 void vita2d_draw_array(SceGxmPrimitiveType mode, const vita2d_color_vertex *vertices, size_t count);
 
-void vita2d_texture_set_alloc_memblock_type(SceKernelMemBlockType type);
-SceKernelMemBlockType vita2d_texture_get_alloc_memblock_type();
+void vita2d_texture_set_alloc_memblock_type(unsigned int type);
+unsigned int vita2d_texture_get_alloc_memblock_type();
 vita2d_texture *vita2d_create_empty_texture(unsigned int w, unsigned int h);
 vita2d_texture *vita2d_create_empty_texture_format(unsigned int w, unsigned int h, SceGxmTextureFormat format);
 vita2d_texture *vita2d_create_empty_texture_rendertarget(unsigned int w, unsigned int h, SceGxmTextureFormat format);

--- a/libvita2d/source/utils.c
+++ b/libvita2d/source/utils.c
@@ -2,7 +2,7 @@
 #include <math.h>
 #include <string.h>
 
-unsigned int get_aligned_size(SceKernelMemBlockType type, unsigned int size)
+unsigned int get_aligned_size(unsigned int type, unsigned int size)
 {
 	switch (type) {
 	case SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW:
@@ -15,7 +15,7 @@ unsigned int get_aligned_size(SceKernelMemBlockType type, unsigned int size)
 	}
 }
 
-void *gpu_alloc(SceKernelMemBlockType type, unsigned int size, unsigned int alignment, unsigned int attribs, SceUID *uid)
+void *gpu_alloc(unsigned int type, unsigned int size, unsigned int alignment, unsigned int attribs, SceUID *uid)
 {
 	void *mem;
 	unsigned int aligned_size = get_aligned_size(type, size);

--- a/libvita2d/source/vita2d_texture.c
+++ b/libvita2d/source/vita2d_texture.c
@@ -7,7 +7,7 @@
 #include "shared.h"
 
 #define GXM_TEX_MAX_SIZE 4096
-static SceKernelMemBlockType MemBlockType = SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW;
+static unsigned int MemBlockType = SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW;
 
 static int tex_format_to_bytespp(SceGxmTextureFormat format)
 {
@@ -37,12 +37,12 @@ static int tex_format_to_bytespp(SceGxmTextureFormat format)
 	}
 }
 
-void vita2d_texture_set_alloc_memblock_type(SceKernelMemBlockType type)
+void vita2d_texture_set_alloc_memblock_type(unsigned int type)
 {
 	MemBlockType = (type == 0) ? SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW : type;
 }
 
-SceKernelMemBlockType vita2d_texture_get_alloc_memblock_type()
+unsigned int vita2d_texture_get_alloc_memblock_type()
 {
 	return MemBlockType;
 }


### PR DESCRIPTION
`SceKernelMemBlockType` doesn't exist anymore. It's simply an SceUInt32 now